### PR TITLE
Factoring out task forward declerations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 target_include_directories(${PROJECT_NAME} INTERFACE include)
 
 target_sources(${PROJECT_NAME} INTERFACE
+  include/TaskTypes.h
   include/Task.h
   include/TaskManager.h
   include/TasksConfig.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,20 @@ project(SquidTasks)
 add_library(${PROJECT_NAME} INTERFACE)
 
 # There doesn't seem to be a coroutines feature in CMAKE_CXX_KNOWN_FEATURES
-target_compile_features(${PROJECT_NAME} INTERFACE "cxx_std_20")
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  target_compile_options(${PROJECT_NAME} INTERFACE "-fcoroutines")
+
+# Some errors in Sample_TextGame with std_20
+#target_compile_features(${PROJECT_NAME} INTERFACE "cxx_std_20")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(${PROJECT_NAME} INTERFACE "-fcoroutines-ts")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 16.10)
+    # Seems like we should use /await:strict here, but seems to fail.
+    #target_compile_options(${PROJECT_NAME} INTERFACE "/await:strict")
+    target_compile_options(${PROJECT_NAME} INTERFACE "/await")
+  else()
+    target_compile_options(${PROJECT_NAME} INTERFACE "/await")
+  endif()
 endif()
 
 target_include_directories(${PROJECT_NAME} INTERFACE include)
@@ -19,4 +30,17 @@ target_sources(${PROJECT_NAME} INTERFACE
   include/TokenList.h
   include/TaskFSM.h
   include/FunctionGuard.h
+  # Private
+  include/Private/TaskPrivate.h
+  include/Private/TaskFSMPrivate.h
+  include/Private/TasksCommonPrivate.h
+  include/Private/tl/optional.hpp
   )
+
+option(SQUIDTASKS_BUILD_SAMPLES "Enable building with samples." OFF)
+
+if(SQUIDTASKS_BUILD_SAMPLES)
+  add_subdirectory(samples/Sample_Tests)
+  add_subdirectory(samples/Sample_Template)
+  add_subdirectory(samples/Sample_TextGame)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(SquidTasks)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+# There doesn't seem to be a coroutines feature in CMAKE_CXX_KNOWN_FEATURES
+target_compile_features(${PROJECT_NAME} INTERFACE "cxx_std_20")
+target_compile_options(${PROJECT_NAME} INTERFACE "-fcoroutines")
+
+target_include_directories(${PROJECT_NAME} INTERFACE include)
+
+target_sources(${PROJECT_NAME} INTERFACE
+  include/Task.h
+  include/TaskManager.h
+  include/TasksConfig.h
+  include/TokenList.h
+  include/TaskFSM.h
+  include/FunctionGuard.h
+  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ add_library(${PROJECT_NAME} INTERFACE)
 
 # There doesn't seem to be a coroutines feature in CMAKE_CXX_KNOWN_FEATURES
 target_compile_features(${PROJECT_NAME} INTERFACE "cxx_std_20")
-target_compile_options(${PROJECT_NAME} INTERFACE "-fcoroutines")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  target_compile_options(${PROJECT_NAME} INTERFACE "-fcoroutines")
+endif()
 
 target_include_directories(${PROJECT_NAME} INTERFACE include)
 

--- a/include/FunctionGuard.h
+++ b/include/FunctionGuard.h
@@ -51,6 +51,9 @@
 //--- User configuration header ---//
 #include "TasksConfig.h"
 
+//--- C++17/C++20 Compatibility ---//
+#include "Private/TasksCommonPrivate.h"
+
 NAMESPACE_SQUID_BEGIN
 
 template <typename tFn = std::function<void()>>

--- a/include/Private/TasksCommonPrivate.h
+++ b/include/Private/TasksCommonPrivate.h
@@ -3,18 +3,6 @@
 //--- User configuration header ---//
 #include "../TasksConfig.h"
 
-// Namespace macros (enabled/disabled via SQUID_ENABLE_NAMESPACE)
-#if SQUID_ENABLE_NAMESPACE
-#define NAMESPACE_SQUID_BEGIN namespace Squid {
-#define NAMESPACE_SQUID_END }
-#define NAMESPACE_SQUID Squid
-#else
-#define NAMESPACE_SQUID_BEGIN
-#define NAMESPACE_SQUID_END
-#define NAMESPACE_SQUID
-namespace Squid {} // Convenience to allow 'using namespace Squid' even when namespace is disabled
-#endif
-
 // Exception macros (to support environments with exceptions disabled)
 #if SQUID_USE_EXCEPTIONS && (defined(__cpp_exceptions) || defined(__EXCEPTIONS))
 #include <stdexcept>

--- a/include/Task.h
+++ b/include/Task.h
@@ -18,6 +18,9 @@
 //--- User configuration header ---//
 #include "TasksConfig.h"
 
+//--- C++17/C++20 Compatibility ---//
+#include "Private/TasksCommonPrivate.h"
+
 //--- Debug Macros ---//
 #if SQUID_ENABLE_TASK_DEBUG
 /// @ingroup Tasks
@@ -45,40 +48,13 @@
 
 NAMESPACE_SQUID_BEGIN
 
+#include "TaskTypes.h"
+
 /// @addtogroup Tasks
 /// @{
 
-//--- Task Reference Type ---//
-enum class eTaskRef /// Whether a handle references a task using a strong or weak reference
-{
-	Strong, ///< Handle will keep the task alive (so long as there exists a valid Resumable handle)
-	Weak, ///< Handle will not the task alive
-};
-
-//--- Task Resumable Type ---//
-enum class eTaskResumable /// Whether a handle can be resumed (all live tasks have exactly one resumable handle and 0+ non-resumable handles)
-{
-	Yes, ///< Handle is resumable
-	No, ///< Handle is not resumable
-};
-
-//--- Task Status ---//
-enum class eTaskStatus /// Status of a task (whether it is currently suspended or done)
-{
-	Suspended, ///< Task is currently suspended
-	Done, ///< Task has terminated and coroutine frame has been destroyed
-};
-
 //--- tTaskCancelFn ---//
 using tTaskCancelFn = std::function<bool()>; ///< CancelIf/StopIf condition function type
-
-// Forward declarations
-template <typename tRet, eTaskRef RefType, eTaskResumable Resumable>
-class Task; /// Templated handle type (defaults to <void, Strong, Resumable>)
-template <typename tRet = void>
-using TaskHandle = Task<tRet, eTaskRef::Strong, eTaskResumable::No>; ///< Non-resumable handle that holds a strong reference to a task
-using WeakTask = Task<void, eTaskRef::Weak, eTaskResumable::Yes>; ///< Resumable handle that holds a weak reference to a task (always void return type)
-using WeakTaskHandle = Task<void, eTaskRef::Weak, eTaskResumable::No>; ///< Non-resumable handle that holds a weak reference to a task (always void return type)
 
 /// @} end of addtogroup Tasks
 
@@ -199,7 +175,7 @@ struct GetStopContext
 /// @tparam tRet Return type of the underlying coroutine (can be void if the coroutine does not co_return a value)
 /// @tparam RefType Whether this handle holds a strong or weak reference to the underlying coroutine
 /// @tparam Resumable Whether this handle can be used to resume the underlying coroutine
-template <typename tRet = void, eTaskRef RefType = eTaskRef::Strong, eTaskResumable Resumable = eTaskResumable::Yes>
+template <typename tRet, eTaskRef RefType, eTaskResumable Resumable>
 class Task
 {
 public:
@@ -594,7 +570,7 @@ private:
 /// Here is an example Squid::GetTime() function implementation from within the ```main.cpp``` file of a sample project:
 ///	
 ///	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~.cpp
-///	NAMESPACE_SQUID_BEGIN
+///	
 ///	tTaskTime GetTime()
 ///	{
 ///		return (tTaskTime)TimeSystem::GetTime();

--- a/include/TaskTypes.h
+++ b/include/TaskTypes.h
@@ -1,0 +1,41 @@
+#pragma once
+
+//--- User configuration header ---//
+#include "TasksConfig.h"
+
+NAMESPACE_SQUID_BEGIN
+/// @addtogroup Tasks
+/// @{
+
+//--- Task Reference Type ---//
+enum class eTaskRef /// Whether a handle references a task using a strong or weak reference
+{
+	Strong, ///< Handle will keep the task alive (so long as there exists a valid Resumable handle)
+	Weak, ///< Handle will not the task alive
+};
+
+//--- Task Resumable Type ---//
+enum class eTaskResumable /// Whether a handle can be resumed (all live tasks have exactly one resumable handle and 0+ non-resumable handles)
+{
+	Yes, ///< Handle is resumable
+	No, ///< Handle is not resumable
+};
+
+//--- Task Status ---//
+enum class eTaskStatus /// Status of a task (whether it is currently suspended or done)
+{
+	Suspended, ///< Task is currently suspended
+	Done, ///< Task has terminated and coroutine frame has been destroyed
+};
+
+// Forward declarations
+template <typename tRet = void, eTaskRef RefType = eTaskRef::Strong, eTaskResumable Resumable = eTaskResumable::Yes>
+class Task; /// Templated handle type (defaults to <void, eTaskRef::Strong, eTaskResumable::Yes>)
+template <typename tRet = void>
+using TaskHandle = Task<tRet, eTaskRef::Strong, eTaskResumable::No>; ///< Non-resumable handle that holds a strong reference to a task
+using WeakTask = Task<void, eTaskRef::Weak, eTaskResumable::Yes>; ///< Resumable handle that holds a weak reference to a task (always void return type)
+using WeakTaskHandle = Task<void, eTaskRef::Weak, eTaskResumable::No>; ///< Non-resumable handle that holds a weak reference to a task (always void return type)
+
+/// @} end of addtogroup Tasks
+
+NAMESPACE_SQUID_END

--- a/include/TasksConfig.h
+++ b/include/TasksConfig.h
@@ -44,5 +44,16 @@
 
 /// @} end of addtogroup Config
 
-//--- C++17/C++20 Compatibility ---//
-#include "Private/TasksCommonPrivate.h"
+// Namespace macros (enabled/disabled via SQUID_ENABLE_NAMESPACE)
+#if SQUID_ENABLE_NAMESPACE
+#define NAMESPACE_SQUID_BEGIN namespace Squid {
+#define NAMESPACE_SQUID_END }
+#define NAMESPACE_SQUID Squid
+#else
+#define NAMESPACE_SQUID_BEGIN
+#define NAMESPACE_SQUID_END
+#define NAMESPACE_SQUID
+namespace Squid {} // Convenience to allow 'using namespace Squid' even when namespace is disabled
+#endif
+
+

--- a/include/TokenList.h
+++ b/include/TokenList.h
@@ -66,6 +66,9 @@
 //--- User configuration header ---//
 #include "TasksConfig.h"
 
+//--- C++17/C++20 Compatibility ---//
+#include "Private/TasksCommonPrivate.h"
+
 NAMESPACE_SQUID_BEGIN
 
 template <typename T = void>

--- a/samples/Sample_Template/CMakeLists.txt
+++ b/samples/Sample_Template/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(Sample_Template)
+
+target_link_libraries(Sample_Template SquidTasks)
+
+target_include_directories(Sample_Template PRIVATE ../Common)
+
+target_sources(Sample_Template PRIVATE
+  ../Common/TimeSystem.h
+   Main.cpp
+)

--- a/samples/Sample_Tests/CMakeLists.txt
+++ b/samples/Sample_Tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(Sample_Tests)
+
+target_link_libraries(Sample_Tests SquidTasks)
+
+target_include_directories(Sample_Tests PRIVATE ../Common)
+
+target_sources(Sample_Tests PRIVATE
+  ../Common/TimeSystem.h
+   Main.cpp
+)

--- a/samples/Sample_TextGame/CMakeLists.txt
+++ b/samples/Sample_TextGame/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(Sample_TextGame)
+
+target_link_libraries(Sample_TextGame SquidTasks)
+
+target_include_directories(Sample_TextGame PRIVATE ../Common)
+
+target_sources(Sample_TextGame PRIVATE
+  ../Common/TimeSystem.h
+  TextGame.h
+  TextInput.h
+  Main.cpp
+)


### PR DESCRIPTION
Factor out task forward declarations to pull in fewer deps in headers that just need to declare a `Task<>` function.

Includes https://github.com/westquote/SquidTasks/pull/5 due to the CMakeLists include, could be trivially rebased out.